### PR TITLE
#26 - remove leading slash

### DIFF
--- a/umich_api/apis.json
+++ b/umich_api/apis.json
@@ -10,7 +10,7 @@
         "limits_period": 60
     },
     "canvasreadonly": {
-        "token_url": "/aa/oauth2/token",
+        "token_url": "aa/oauth2/token",
         "limits_calls": 20000,
         "limits_period": 1
     },


### PR DESCRIPTION
As mentioned in #26, remove leading slash from `token_url` of the `canvasreadonly` service.

Fixes #26.