### PR TITLE
Extend requirement ranges in setup.py (#28)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@ setup(
     package_data={'umich_api': ['apis.json']},
     install_requires=[
         'ratelimit>=2.2.0,<2.2.99',
-        'requests>=2.20.0,<2.22.99',
-        'python-dotenv==0.9.1',
-        'autologging==1.2',
+        'requests>=2.20.0,<2.24.99',
+        'python-dotenv>=0.9.1,<0.14.99',
+        'autologging>=1.2.0,<1.3.99',
     ],
     setup_requires=['setuptools_scm',],
     tests_require=[],

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ setup(
     packages=['umich_api'],
     package_data={'umich_api': ['apis.json']},
     install_requires=[
-        'ratelimit>=2.2.0,<2.2.99',
-        'requests>=2.20.0,<2.24.99',
-        'python-dotenv>=0.9.1,<0.14.99',
         'autologging>=1.2.0,<1.3.99',
+        'python-dotenv>=0.9.1,<0.14.99',
+        'ratelimit>=2.2.0,<2.2.99',
+        'requests>=2.20.0,<2.24.99'
     ],
     setup_requires=['setuptools_scm',],
     tests_require=[],


### PR DESCRIPTION
This PR extends the ranges for `autologging`, `python-dotenv`, and `requests` to include the latest release and any future patch releases. I tested this by running the project's test suite and by running `placement-exams` off my branch (both its test suite and the regular workflow). The PR aims to resolve issue #28.