### PR TITLE
Add integration test for mcommunitygroups (#30)

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -32,7 +32,14 @@ class TestApiCalls(unittest.TestCase):
         uniqname = "uniqname"
         self.assertEqual(self.apiutil.api_call(f"MCommunity/People/{uniqname}", "mcommunity").status_code, 200)
 
-    # Tests API mcommunity calls
+    def test_mcommunitygroups(self):
+        response_to_fake = self.apiutil.api_call(f'MCommunityGroups/Members/Fake Hacky Sack Club', 'mcommunitygroups')
+        self.assertEqual(response_to_fake.status_code, 200)
+        self.assertTrue(json.loads(response_to_fake.text)['MCommunityInfo'] is None)
+        response_to_real = self.apiutil.api_call(f'MCommunityGroups/Members/ITS Teaching and Learning', 'mcommunitygroups')
+        self.assertTrue(response_to_real.status_code, 200)
+        self.assertTrue(json.loads(response_to_real.text)['MCommunityInfo'] is not None)
+
     def test_umscheduleofclasses(self):
         self.assertEqual(self.apiutil.api_call(f"Curriculum/SOC/Terms", "umscheduleofclasses").status_code, 200)
 


### PR DESCRIPTION
This PR adds an integration test for the `mcommunitygroups` scope/endpoint in the API Directory. Because I have opted not to add any additional integration tests at this time, this PR aims to resolve issue #30. See the issue for my reasoning for not writing more tests (essentially it doesn't seem appropriate to ask for subscriptions for the remaining scopes).