### PR TITLE
Add connection and 50X retry capability (#35)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
         'autologging>=1.2.0,<1.3.99',
         'python-dotenv>=0.9.1,<0.14.99',
         'ratelimit>=2.2.0,<2.2.99',
-        'requests>=2.20.0,<2.24.99'
+        'requests>=2.20.0,<2.26.99',
+        'urllib3>=1.21.1,<1.27'
     ],
     setup_requires=['setuptools_scm',],
     tests_require=[],


### PR DESCRIPTION
This PR aims to resolve #35. It is still currently a draft.

I'm still investigating whether this is really necessary, but having greater control over this makes sense to me. The test suite as is passed.

If this looks good, I can at least add a test with a customization of the `max_retries` constructor parameter. I'm not sure how I would go about writing a test with connection or status code retries for this.

Resource(s):
- https://2.python-requests.org/en/master/api/#request-sessions
- https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html
- https://stackoverflow.com/questions/23013220/max-retries-exceeded-with-url-in-requests/47475019#47475019